### PR TITLE
Adiciona workflow de Linter no Github Action

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,21 @@
+name: MarkdownLint
+
+on: [push]
+
+jobs:
+  mdl:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    
+    - name: Install MarkdownLint (mdl)
+      run:  gem install mdl
+
+    - name: Run linter
+      run: mdl docs/


### PR DESCRIPTION
Esse commit habilita e configura o primeiro Github Action workflow
para executar o MarkdownLint (mdl) sobre o conteúdo do workshop.

Fixes #52 .