### PR TITLE
Desabilitando regra MD013 no linter

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -18,4 +18,4 @@ jobs:
       run:  gem install mdl
 
     - name: Run linter
-      run: mdl docs/
+      run: mdl -r ~MD013 docs/


### PR DESCRIPTION
<!-- Esse template vai nos ajudar a te ajudar! Use o modelo pra acelerar o processo de merge. -->

**Qual o tipo desse PR (bug, cleaup, feature)?**:
bug

**O que esse PR faz, ou porquê é necessário?**:
A regra MD013 é a que determina tamanho máximo de 80 caracteres para as linhas do arquivo markdown. Essa regra não agrega para o nosso projeto, e complica o desenvolvimento e revisão do conteúdo.

**Qual, ou quais, Issues esse PR endereça?**:
<!-- Se não houver nenhum, crie um Issue antes de fazer o PR. -->
<!-- Use a expressão abaixo para cada Issue relacionada. -->
Fixes #67 