### PR TITLE
Update lab-1.1-executar.md

### DIFF
--- a/parte-1-linux-containers/lab-1.1-executar.md
+++ b/parte-1-linux-containers/lab-1.1-executar.md
@@ -166,7 +166,7 @@ Caso queira entrar em um container já em execução, para fazer _attach_ no pro
 Uma das vantagens do uso de containers é a possibilidade de abstração da complexidade de implantação de um determinado serviço. Vamos rodar agora uma imagem do wordpress e ver o trabalho necessário para colocar esse CMS no ar.
 
 ```text
-docker run --rm -p 80:8080 wordpress
+docker run --rm -p 8080:80 wordpress
 ```
 
 O parametro -p exporta a porta interna do container \(80\) para a nossa máquina na porta 8080. Esse parâmetro será explicado melhor nos próximos exercícios.


### PR DESCRIPTION
docker run --rm -p 8080:80 wordpress
Imagem do wordpress roda na porta 80 por padrão.  Logo, o comando correto seria -p 8080:80 e não o contrário. Caso deixe como estava, não irá conseguir estabelecer conexão com o wordpress.

<!-- Esse template vai nos ajudar a te ajudar! Use o modelo pra acelerar o processo de merge. -->

**Qual o tipo desse PR (bug, cleaup, feature)?**:
bug

**O que esse PR faz, ou porquê é necessário?**:
corrige um erro na hora de rodar o wordpress. Está direcionando para a porta errada e não estabelece comunicação.

**Qual, ou quais, Issues esse PR endereça?**:
Fixes #72 